### PR TITLE
Documentation formatting fixes and config file fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ but not me!
 ```
 "but not me!" is not added to the index
 
-FollowFilters: Works quite the same as IndexFilters, only these are applied just before gathering all <a> tags to crawl. So using the above sample, if you have this html:
+FollowFilters: Works quite the same as IndexFilters, only these are applied just before gathering all ```<a>``` tags to crawl. So using the above sample, if you have this html:
 ```
 <b>you can index me</b>
 <a href="follow.aspx">follow me</a>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ As so many Sitecore modules, this module also allows you to configure it through
 
 A sample configuration would be App_Config/Includes/efocus.websearch.config
 ```
-<sitecore>
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
   <sitecore>
     <pipelines>
@@ -88,12 +87,15 @@ but not me!
 ```
 "but not me!" is not added to the index
 
-FollowFilters: Works quite the same as IndexFilters, only these are applied just before gathering all <a> tags to crawl. So using the above sample, if you have this html:<b>you can index me</b>
+FollowFilters: Works quite the same as IndexFilters, only these are applied just before gathering all <a> tags to crawl. So using the above sample, if you have this html:
+```
+<b>you can index me</b>
 <a href="follow.aspx">follow me</a>
 <!-- BEGIN-NOFOLLOW -->
 <a href="follownot.aspx">but not me!</a>
 <!-- END-NOFOLLOW -->
 <a href="follownot" rel="nofollow">me neither</a>
+```
 The links 'but not me' and 'me neither' are not crawled
 Also, if you add a <meta name="robots" content="nofollow" /> to your <head> , not any link on the entire page will be crawled 
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ FollowFilters: Works quite the same as IndexFilters, only these are applied just
 <a href="follownot" rel="nofollow">me neither</a>
 ```
 The links 'but not me' and 'me neither' are not crawled
-Also, if you add a <meta name="robots" content="nofollow" /> to your <head> , not any link on the entire page will be crawled 
+Also, if you add a ```<meta name="robots" content="nofollow" />``` to your ```<head>``` , not any link on the entire page will be crawled 
 
 ##Usage
 For getting results from your indexed content, you can use the Efocus.Sitecore.LuceneWebSearch.Searcher class.

--- a/configsample.config
+++ b/configsample.config
@@ -1,4 +1,3 @@
-<sitecore>
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
   <sitecore>
     <pipelines>


### PR DESCRIPTION
Here's a couple of things I found while looking at implementing your code on my sitecore 7 site. 

The main thing is README.md formatting, however I also removed the first <sitecore> tag from the .config file in the sample and in the README.md copy.
